### PR TITLE
fix merge method

### DIFF
--- a/src/Commerble.Postal.Tests/NormalizarTest.cs
+++ b/src/Commerble.Postal.Tests/NormalizarTest.cs
@@ -422,6 +422,9 @@ namespace Commerble.Postal.Tests
             var raw = postalFetcher.RawPostalList.Select(p => p.Code).Distinct().OrderBy(p => p);
             var normalized = postalFetcher.NormalizedPostalList.Select(p => p.Code).Distinct().OrderBy(p => p);
 
+            Console.WriteLine("raw: {0}件", raw.Count());
+            Console.WriteLine("normalized: {0}件", normalized.Count());
+
             var diff = raw.Except(normalized);
             Console.WriteLine("raw - normalized: {0}件", diff.Count());
             foreach (var code in diff)

--- a/src/Commerble.Postal/PostalNormalizar.cs
+++ b/src/Commerble.Postal/PostalNormalizar.cs
@@ -16,7 +16,7 @@ namespace Commerble.Postal
             {
                 var current = list[i];
                 // 開始カッコとカンマがあったら、先行してる行を郵便番号が同じ間連結していく
-                if (current.Street.Contains("（") && current.Street.Contains("、"))
+                if (current.Street.Contains("（") && (current.Street.Contains("、") || current.Street.Contains("・")))
                 {
                     for (; i + 1 < list.Length && current.Code == list[i + 1].Code;)
                     {


### PR DESCRIPTION
マージの必要な行の新パターンに対応させるため条件を変更

```
# 新パターン
13113,"150  ","1506290","ﾄｳｷｮｳﾄ","ｼﾌﾞﾔｸ","ｻｸﾗｶﾞｵｶﾁｮｳｼﾌﾞﾔｻｸﾗｽﾃｰｼﾞｼﾌﾞﾔｻｲﾄﾞｼﾌﾞﾔﾀﾜｰ(ﾁｶｲ･","東京都","渋谷区","桜丘町渋谷サクラステージＳＨＩＢＵＹＡサイドＳＨＩＢＵＹＡタワー（地階・",0,0,0,0,0,0
13113,"150  ","1506290","ﾄｳｷｮｳﾄ","ｼﾌﾞﾔｸ","ｶｲｿｳﾌﾒｲ)","東京都","渋谷区","階層不明）",0,0,0,0,0,0
```